### PR TITLE
Add startimap shortcut

### DIFF
--- a/bin/.local/bin/startimap
+++ b/bin/.local/bin/startimap
@@ -1,0 +1,13 @@
+#! /usr/bin/env bash
+
+session="offlineimap"
+
+tmux has-session -t $session 2>/dev/null
+
+
+if [ $? == 0 ]; then
+	echo "imap session already exists"
+else
+	echo "starting imap session"
+	tmux new -d -s offlineimap -n imap offlineimap
+fi


### PR DESCRIPTION
Adds a shortcut command that checks if an offlineimap tmux session already exists and creates one if it does not. Thus creating an easy interface to make sure my mutt inbox is up to date.